### PR TITLE
Plasma 6.6 fixes + tile-aware snap detection

### DIFF
--- a/contents/ui/code/assist.js
+++ b/contents/ui/code/assist.js
@@ -1,10 +1,17 @@
 /// assist
 function delayedShowAssist(dx, dy, height, width, window){
-    allClients = Object.values(KWinComponents.Workspace.windows);
+    /// Workspace.windows is a QQmlListProperty (.length + numeric index access),
+    /// not a real array — Object.values() returns [] for it. Iterate by index.
+    const _ws = KWinComponents.Workspace.windows;
+    allClients = [];
+    for (let i = 0; i < _ws.length; ++i) allClients.push(_ws[i]);
     clients = allClients.filter(c => WindowManager.shouldShowWindow(c));
     if (clients.length == 0) return;
 
-    cardWidth = currentScreenWidth / 5;
+    /// Cap card width to fit inside the chooser. Otherwise a single card spills
+    /// out of narrow tiles (e.g. a 25%-wide custom tile).
+    const _chooserW = width || (currentScreenWidth - (window ? window.width : 0));
+    cardWidth = Math.min(currentScreenWidth / 5, Math.max(80, _chooserW - gridSpacing * 2));
     cardHeight = cardWidth / 1.68;
     lastActiveClient = KWinComponents.Workspace.activeWindow;
 
@@ -116,6 +123,7 @@ function finishSnap(success){
     visibleWindowPreviews = [];
     quatersToShowNext = {};
     lastActiveClient = null;
+    currentTargetTile = null;
 }
 
 
@@ -130,6 +138,7 @@ function checkToShowNextQuaterAssist(lastSelectedClient){
         const nextQuater = quatersToShowNext[keys[0]];
         delete quatersToShowNext[keys[0]];
         if (layoutMode !== 3) columnsCount = 2;
+        currentTargetTile = nextQuater._tile || null;
         delayedShowAssist(nextQuater.dx, nextQuater.dy, nextQuater.height, nextQuater.width);
         if (lastSelectedClient) lastActiveClient = lastSelectedClient;
         return true;

--- a/contents/ui/code/keyboard.js
+++ b/contents/ui/code/keyboard.js
@@ -12,17 +12,29 @@ function moveFocusRight() {
     scrollItemIntoView(focusedIndex);
 }
 
+/// The chooser Grid computes its column count dynamically (capped by actual
+/// candidate count and what fits in the chooser width). Up/down navigation
+/// must use that effective value, not the static layout columnsCount, or a
+/// single-column chooser tries to jump by 2 rows and the move is rejected.
+function _effectiveColumns() {
+    const fit = Math.floor((scrollView.width + gridSpacing) / (cardWidth + gridSpacing));
+    return Math.max(1, Math.min(
+        clients ? clients.length : 1,
+        Math.min(columnsCount, fit)));
+}
+
 function moveFocusUp(){
-    if(focusedIndex - columnsCount >= 0) {
-        focusedIndex = focusedIndex - columnsCount;
+    const cols = _effectiveColumns();
+    if(focusedIndex - cols >= 0) {
+        focusedIndex = focusedIndex - cols;
         scrollItemIntoView(focusedIndex);
     }
 }
 
 function moveFocusDown(){
-    const clientsLen = clients.length;
-    if(focusedIndex + columnsCount < clients.length) {
-        focusedIndex = focusedIndex + columnsCount;
+    const cols = _effectiveColumns();
+    if(focusedIndex + cols < clients.length) {
+        focusedIndex = focusedIndex + cols;
         scrollItemIntoView(focusedIndex);
     } else {
         focusedIndex =  clients.length - 1;

--- a/contents/ui/code/windows.js
+++ b/contents/ui/code/windows.js
@@ -304,11 +304,14 @@ function onWindowResize(window) {
     }
 }
 
-/// Plasma 6 tile-aware snap detection. Triggered when a window enters/leaves a Tile.
-/// Strategy: compute empty regions geometrically (work area minus the snapped
-/// window's frame), then try to match each empty strip to a real Tile in the
-/// parent's subtree so we can use Tile.manage() for placement; otherwise fall
-/// back to plain frameGeometry placement.
+/// Plasma 6 tile-aware snap detection. Triggered when a window enters/leaves
+/// a Tile. Picks a strategy based on the parent's structure:
+///   - If sibling tiles don't overlap (typical custom layout), each empty
+///     sibling becomes its own chooser entry with its Tile reference, so
+///     placement runs through KWin's tile system and the tile padding is
+///     applied to the chosen window.
+///   - If siblings overlap (Plasma's quick-tile pseudo-tree), fall back to
+///     a geometric complement: work area minus the snapped window's frame.
 function onTileChanged(window) {
     if (activated || !window || window.deleted || window.specialWindow || !window.active) return;
     const tile = window.tile;
@@ -350,14 +353,8 @@ function onTileChanged(window) {
         occRect = _fg || _tg;
     }
 
-    /// Decide which strategy to use:
-    ///  - If the dropped tile has clean non-overlapping siblings (typical
-    ///    custom tile layouts), iterate parent.tiles directly so each sibling
-    ///    becomes its own chooser entry with its own Tile reference. This is
-    ///    what lets KWin's tile system apply padding when the user picks one.
-    ///  - Otherwise (Plasma's quick-tile tree where halves/corners/strips all
-    ///    overlap), compute the empty region geometrically as work-area minus
-    ///    the dropped window's frame.
+    /// Strategy switch: tile-tree iteration if siblings are clean, otherwise
+    /// geometric complement (see function header for rationale).
     const parent = tile.parent;
     const siblings = parent && parent.tiles;
     let useTileTree = false;

--- a/contents/ui/code/windows.js
+++ b/contents/ui/code/windows.js
@@ -45,22 +45,26 @@ function selectClient(client){
     if (rememberWindowSizes)
         windowSizesBeforeSnap[client.internalId] = { height: client.height, width: client.width };
 
-    client.frameGeometry = immersiveMode ? Qt.rect(
-        mainWindow.x - (assistPadding / 2) + minDx,
-        mainWindow.y - (assistPadding / 2) + minDy,
-        mainWindow.width + assistPadding,
-        mainWindow.height + assistPadding
-    ) : Qt.rect(
-        main.x - (assistPadding / 2),
-        main.y - (assistPadding / 2),
-        main.width + assistPadding,
-        main.height + assistPadding
-    );
-
-    /// If onTileChanged matched a target Tile, hand placement off to KWin's
-    /// tile system. Tile.manage() applies tile padding & work-area clamping.
-    if (currentTargetTile && currentTargetTile.manage) {
-        currentTargetTile.manage(client);
+    if (currentTargetTile) {
+        /// Assign the tile and let KWin position the window via its internal
+        /// tile system. The setter (setTileCompatibility) triggers a
+        /// moveResize to windowGeometry (= absolute bounds inset by padding).
+        /// Setting frameGeometry first would lock the window flush against
+        /// the bounds and skip the padding step entirely.
+        client.tile = currentTargetTile;
+    } else {
+        /// Fallback when no tile matched: place via raw frameGeometry.
+        client.frameGeometry = immersiveMode ? Qt.rect(
+            mainWindow.x - (assistPadding / 2) + minDx,
+            mainWindow.y - (assistPadding / 2) + minDy,
+            mainWindow.width + assistPadding,
+            mainWindow.height + assistPadding
+        ) : Qt.rect(
+            main.x - (assistPadding / 2),
+            main.y - (assistPadding / 2),
+            main.width + assistPadding,
+            main.height + assistPadding
+        );
     }
 }
 
@@ -316,36 +320,12 @@ function onTileChanged(window) {
     currentScreenWidth = Math.floor(maxArea.width); currentScreenHeight = Math.floor(maxArea.height);
     minDx = Math.ceil(maxArea.x); minDy = Math.ceil(maxArea.y);
 
-    /// Occupied region = bounding-box union of tile.geometry and window.frameGeometry,
-    /// clipped to work area. Neither alone is reliable on Plasma 6.6.
-    const _tg = tile.absoluteGeometryInScreen || tile.absoluteGeometry;
-    const _fg = window.frameGeometry;
-    let occX0, occY0, occX1, occY1;
-    if (_tg && _fg) {
-        occX0 = Math.min(_tg.x, _fg.x); occY0 = Math.min(_tg.y, _fg.y);
-        occX1 = Math.max(_tg.x + _tg.width,  _fg.x + _fg.width);
-        occY1 = Math.max(_tg.y + _tg.height, _fg.y + _fg.height);
-    } else {
-        const g = _fg || _tg;
-        occX0 = g.x; occY0 = g.y; occX1 = g.x + g.width; occY1 = g.y + g.height;
-    }
     const wx0 = maxArea.x, wy0 = maxArea.y;
     const wx1 = maxArea.x + maxArea.width, wy1 = maxArea.y + maxArea.height;
-    occX0 = Math.max(occX0, wx0); occY0 = Math.max(occY0, wy0);
-    occX1 = Math.min(occX1, wx1); occY1 = Math.min(occY1, wy1);
 
-    /// Up to 4 strips around the occupied rect.
-    const strips = [];
-    if (occY0 > wy0) strips.push({ x: wx0, y: wy0, width: wx1 - wx0, height: occY0 - wy0 });
-    if (occY1 < wy1) strips.push({ x: wx0, y: occY1, width: wx1 - wx0, height: wy1 - occY1 });
-    if (occX0 > wx0) strips.push({ x: wx0, y: occY0, width: occX0 - wx0, height: occY1 - occY0 });
-    if (occX1 < wx1) strips.push({ x: occX1, y: occY0, width: wx1 - occX1, height: occY1 - occY0 });
-
-    function _rectsEqual(a, b) {
-        const tol = 4;
-        return Math.abs(a.x - b.x) <= tol && Math.abs(a.y - b.y) <= tol &&
-               Math.abs(a.width  - b.width)  <= tol &&
-               Math.abs(a.height - b.height) <= tol;
+    function _rectsOverlap(a, b) {
+        return !(a.x + a.width  <= b.x || a.x >= b.x + b.width ||
+                 a.y + a.height <= b.y || a.y >= b.y + b.height);
     }
     function _tileIsEmpty(t) {
         if (t.windows && t.windows.length > 0) return false;
@@ -356,31 +336,86 @@ function onTileChanged(window) {
         }
         return true;
     }
-    function _findTileMatching(root, target) {
-        if (!root) return null;
-        if (_tileIsEmpty(root)) {
-            const g = root.absoluteGeometryInScreen || root.absoluteGeometry;
-            if (g && _rectsEqual(g, target)) return root;
-        }
-        if (root.tiles) {
-            for (let i = 0; i < root.tiles.length; i++) {
-                const m = _findTileMatching(root.tiles[i], target);
-                if (m) return m;
+
+    /// "Occupied region" = bounding-box union of tile.geometry and window.frameGeometry.
+    const _tg = tile.absoluteGeometryInScreen || tile.absoluteGeometry;
+    const _fg = window.frameGeometry;
+    let occRect;
+    if (_tg && _fg) {
+        const x0 = Math.min(_tg.x, _fg.x), y0 = Math.min(_tg.y, _fg.y);
+        const x1 = Math.max(_tg.x + _tg.width,  _fg.x + _fg.width);
+        const y1 = Math.max(_tg.y + _tg.height, _fg.y + _fg.height);
+        occRect = { x: x0, y: y0, width: x1 - x0, height: y1 - y0 };
+    } else {
+        occRect = _fg || _tg;
+    }
+
+    /// Decide which strategy to use:
+    ///  - If the dropped tile has clean non-overlapping siblings (typical
+    ///    custom tile layouts), iterate parent.tiles directly so each sibling
+    ///    becomes its own chooser entry with its own Tile reference. This is
+    ///    what lets KWin's tile system apply padding when the user picks one.
+    ///  - Otherwise (Plasma's quick-tile tree where halves/corners/strips all
+    ///    overlap), compute the empty region geometrically as work-area minus
+    ///    the dropped window's frame.
+    const parent = tile.parent;
+    const siblings = parent && parent.tiles;
+    let useTileTree = false;
+    if (parent && siblings && siblings.length >= 2) {
+        useTileTree = true;
+        outer: for (let i = 0; i < siblings.length; i++) {
+            const a = siblings[i].absoluteGeometryInScreen || siblings[i].absoluteGeometry;
+            if (!a) continue;
+            for (let j = i + 1; j < siblings.length; j++) {
+                const b = siblings[j].absoluteGeometryInScreen || siblings[j].absoluteGeometry;
+                if (b && _rectsOverlap(a, b)) { useTileTree = false; break outer; }
             }
         }
-        return null;
     }
-    const searchRoot = tile.parent || tile;
 
     quatersToShowNext = {};
     let idx = 0;
-    for (const s of strips) {
-        const cx0 = Math.ceil(s.x), cy0 = Math.ceil(s.y);
-        const cx1 = Math.floor(s.x + s.width), cy1 = Math.floor(s.y + s.height);
-        if (cx1 <= cx0 || cy1 <= cy0) continue;
-        const rect = { x: cx0, y: cy0, width: cx1 - cx0, height: cy1 - cy0 };
-        const matched = _findTileMatching(searchRoot, rect);
-        quatersToShowNext[idx++] = { dx: rect.x, dy: rect.y, width: rect.width, height: rect.height, _tile: matched };
+
+    if (useTileTree) {
+        /// Iterate parent.tiles directly. We do NOT check overlap against the
+        /// dropped window's bounding box — useTileTree only triggers when
+        /// siblings are non-overlapping by definition, and KWin can place the
+        /// dropped window a hair outside its own tile (padding rounding) which
+        /// then erroneously filters a legitimate empty sibling.
+        for (let i = 0; i < siblings.length; i++) {
+            const sib = siblings[i];
+            if (sib === tile) continue;
+            if (!_tileIsEmpty(sib)) continue; /// don't suggest already-occupied tiles
+            const g = sib.absoluteGeometryInScreen || sib.absoluteGeometry;
+            if (!g) continue;
+            const cx0 = Math.ceil(Math.max(g.x, wx0));
+            const cy0 = Math.ceil(Math.max(g.y, wy0));
+            const cx1 = Math.floor(Math.min(g.x + g.width,  wx1));
+            const cy1 = Math.floor(Math.min(g.y + g.height, wy1));
+            if (cx1 <= cx0 || cy1 <= cy0) continue;
+            quatersToShowNext[idx++] = {
+                dx: cx0, dy: cy0, width: cx1 - cx0, height: cy1 - cy0, _tile: sib,
+            };
+        }
+    } else {
+        /// Geometric complement = work area minus the occupied rect (clipped).
+        const occX0 = Math.max(occRect.x, wx0);
+        const occY0 = Math.max(occRect.y, wy0);
+        const occX1 = Math.min(occRect.x + occRect.width,  wx1);
+        const occY1 = Math.min(occRect.y + occRect.height, wy1);
+        const strips = [];
+        if (occY0 > wy0) strips.push({ x: wx0, y: wy0, width: wx1 - wx0, height: occY0 - wy0 });
+        if (occY1 < wy1) strips.push({ x: wx0, y: occY1, width: wx1 - wx0, height: wy1 - occY1 });
+        if (occX0 > wx0) strips.push({ x: wx0, y: occY0, width: occX0 - wx0, height: occY1 - occY0 });
+        if (occX1 < wx1) strips.push({ x: occX1, y: occY0, width: wx1 - occX1, height: occY1 - occY0 });
+        for (const s of strips) {
+            const cx0 = Math.ceil(s.x), cy0 = Math.ceil(s.y);
+            const cx1 = Math.floor(s.x + s.width), cy1 = Math.floor(s.y + s.height);
+            if (cx1 <= cx0 || cy1 <= cy0) continue;
+            quatersToShowNext[idx++] = {
+                dx: cx0, dy: cy0, width: cx1 - cx0, height: cy1 - cy0, _tile: null,
+            };
+        }
     }
 
     if (idx === 0) return;

--- a/contents/ui/code/windows.js
+++ b/contents/ui/code/windows.js
@@ -56,6 +56,12 @@ function selectClient(client){
         main.width + assistPadding,
         main.height + assistPadding
     );
+
+    /// If onTileChanged matched a target Tile, hand placement off to KWin's
+    /// tile system. Tile.manage() applies tile padding & work-area clamping.
+    if (currentTargetTile && currentTargetTile.manage) {
+        currentTargetTile.manage(client);
+    }
 }
 
 function onClientSelect(client){
@@ -76,7 +82,6 @@ function addListenersToClient(client) {
 
     client.frameGeometryChanged.connect(function() {
         if (!client.move && !client.resize && activated == false && preventFromShowing == false) {
-            console.error("addListenersToClient -> frameGeometryChanged")
             if (delayBeforeShowingAssist == 0) {
                 onWindowResize(client);
             } else {
@@ -86,6 +91,35 @@ function addListenersToClient(client) {
             }
         }
     });
+
+    /// Plasma 6: the QML `tile` property's NOTIFY (`tileChanged`) only fires when
+    /// the committed tile changes, but Shift+drag drops set `requestedTile` —
+    /// which doesn't trigger `tileChanged`. interactiveMoveResizeFinished is the
+    /// reliable hook: after drag ends, if window.tile is set, the window was
+    /// dropped into a tile.
+    if (client.interactiveMoveResizeFinished) {
+        client.interactiveMoveResizeFinished.connect(function(){
+            if (activated || preventFromShowing) return;
+            if (!client.tile) return; /// not dropped into a tile
+            if (delayBeforeShowingAssist == 0) {
+                onTileChanged(client);
+            } else {
+                timer.setTimeout(function(){ onTileChanged(client); }, delayBeforeShowingAssist);
+            }
+        });
+    }
+
+    /// Fallback: still wire tileChanged in case some KWin paths emit it.
+    if (client.tileChanged) {
+        client.tileChanged.connect(function() {
+            if (activated || preventFromShowing) return;
+            if (delayBeforeShowingAssist == 0) {
+                onTileChanged(client);
+            } else {
+                timer.setTimeout(function(){ onTileChanged(client); }, delayBeforeShowingAssist);
+            }
+        });
+    }
 
     client.interactiveMoveResizeStarted.connect(function(){
         if (trackSnappedWindows && !client.resize)
@@ -143,17 +177,18 @@ function addListenersToClient(client) {
 }
 
 function onWindowResize(window) {
-    console.error("console.error", window)
-    // print("print", window)
     if (activated || !window || window.deleted || window.specialWindow || !window.active) return;
+    /// On Plasma 6, snaps assign a tile object — let onTileChanged handle those.
+    if (window.tile) return;
     AssistManager.finishSnap(false); /// make sure we cleared all variables
 
     /// don't show assist if window could be fit in the group behind
     if (fitWindowInGroupBehind && windowFitsInSnapGroup(window)) return;
     const maxArea = KWinComponents.Workspace.clientArea(KWin.MaximizeArea, window);
-    console.error(maxArea.x,maxArea.y,maxArea.width,maxArea.height)
-    currentScreenWidth = maxArea.width; currentScreenHeight = maxArea.height;
-    minDx = maxArea.x; minDy = maxArea.y;
+    /// Ceil work-area origin so fractional scaling doesn't shave a pixel off
+    /// the placed window (would otherwise sit under the panel).
+    currentScreenWidth = Math.floor(maxArea.width); currentScreenHeight = Math.floor(maxArea.height);
+    minDx = Math.ceil(maxArea.x); minDy = Math.ceil(maxArea.y);
     const dx = window.x, dy = window.y;
     const width = window.width, height = window.height;
     const halfScreenWidth = currentScreenWidth / 2, halfScreenHeight = currentScreenHeight / 2;
@@ -263,6 +298,97 @@ function onWindowResize(window) {
         cardWidth *= 1.2;
         cardHeight *= 1.2;
     }
+}
+
+/// Plasma 6 tile-aware snap detection. Triggered when a window enters/leaves a Tile.
+/// Strategy: compute empty regions geometrically (work area minus the snapped
+/// window's frame), then try to match each empty strip to a real Tile in the
+/// parent's subtree so we can use Tile.manage() for placement; otherwise fall
+/// back to plain frameGeometry placement.
+function onTileChanged(window) {
+    if (activated || !window || window.deleted || window.specialWindow || !window.active) return;
+    const tile = window.tile;
+    if (!tile) return;
+
+    AssistManager.finishSnap(false);
+
+    const maxArea = KWinComponents.Workspace.clientArea(KWin.MaximizeArea, window);
+    currentScreenWidth = Math.floor(maxArea.width); currentScreenHeight = Math.floor(maxArea.height);
+    minDx = Math.ceil(maxArea.x); minDy = Math.ceil(maxArea.y);
+
+    /// Occupied region = bounding-box union of tile.geometry and window.frameGeometry,
+    /// clipped to work area. Neither alone is reliable on Plasma 6.6.
+    const _tg = tile.absoluteGeometryInScreen || tile.absoluteGeometry;
+    const _fg = window.frameGeometry;
+    let occX0, occY0, occX1, occY1;
+    if (_tg && _fg) {
+        occX0 = Math.min(_tg.x, _fg.x); occY0 = Math.min(_tg.y, _fg.y);
+        occX1 = Math.max(_tg.x + _tg.width,  _fg.x + _fg.width);
+        occY1 = Math.max(_tg.y + _tg.height, _fg.y + _fg.height);
+    } else {
+        const g = _fg || _tg;
+        occX0 = g.x; occY0 = g.y; occX1 = g.x + g.width; occY1 = g.y + g.height;
+    }
+    const wx0 = maxArea.x, wy0 = maxArea.y;
+    const wx1 = maxArea.x + maxArea.width, wy1 = maxArea.y + maxArea.height;
+    occX0 = Math.max(occX0, wx0); occY0 = Math.max(occY0, wy0);
+    occX1 = Math.min(occX1, wx1); occY1 = Math.min(occY1, wy1);
+
+    /// Up to 4 strips around the occupied rect.
+    const strips = [];
+    if (occY0 > wy0) strips.push({ x: wx0, y: wy0, width: wx1 - wx0, height: occY0 - wy0 });
+    if (occY1 < wy1) strips.push({ x: wx0, y: occY1, width: wx1 - wx0, height: wy1 - occY1 });
+    if (occX0 > wx0) strips.push({ x: wx0, y: occY0, width: occX0 - wx0, height: occY1 - occY0 });
+    if (occX1 < wx1) strips.push({ x: occX1, y: occY0, width: wx1 - occX1, height: occY1 - occY0 });
+
+    function _rectsEqual(a, b) {
+        const tol = 4;
+        return Math.abs(a.x - b.x) <= tol && Math.abs(a.y - b.y) <= tol &&
+               Math.abs(a.width  - b.width)  <= tol &&
+               Math.abs(a.height - b.height) <= tol;
+    }
+    function _tileIsEmpty(t) {
+        if (t.windows && t.windows.length > 0) return false;
+        if (t.tiles && t.tiles.length > 0) {
+            for (let i = 0; i < t.tiles.length; i++) {
+                if (!_tileIsEmpty(t.tiles[i])) return false;
+            }
+        }
+        return true;
+    }
+    function _findTileMatching(root, target) {
+        if (!root) return null;
+        if (_tileIsEmpty(root)) {
+            const g = root.absoluteGeometryInScreen || root.absoluteGeometry;
+            if (g && _rectsEqual(g, target)) return root;
+        }
+        if (root.tiles) {
+            for (let i = 0; i < root.tiles.length; i++) {
+                const m = _findTileMatching(root.tiles[i], target);
+                if (m) return m;
+            }
+        }
+        return null;
+    }
+    const searchRoot = tile.parent || tile;
+
+    quatersToShowNext = {};
+    let idx = 0;
+    for (const s of strips) {
+        const cx0 = Math.ceil(s.x), cy0 = Math.ceil(s.y);
+        const cx1 = Math.floor(s.x + s.width), cy1 = Math.floor(s.y + s.height);
+        if (cx1 <= cx0 || cy1 <= cy0) continue;
+        const rect = { x: cx0, y: cy0, width: cx1 - cx0, height: cy1 - cy0 };
+        const matched = _findTileMatching(searchRoot, rect);
+        quatersToShowNext[idx++] = { dx: rect.x, dy: rect.y, width: rect.width, height: rect.height, _tile: matched };
+    }
+
+    if (idx === 0) return;
+
+    filteredClients.push(window);
+    layoutMode = 1;
+    columnsCount = 2;
+    AssistManager.checkToShowNextQuaterAssist(window);
 }
 
 function handleWindowFocus(window) {
@@ -472,13 +598,18 @@ function isEqual(a, b) {
 
 function getClientFromId(windowId){
     //return workspace.getClient(windowId); /// doesn't work on Wayland
-    if (!allClients) allClients = Object.values(KWinComponents.Workspace.windows);
+    if (!allClients) {
+        const _ws = KWinComponents.Workspace.windows;
+        allClients = [];
+        for (let i = 0; i < _ws.length; ++i) allClients.push(_ws[i]);
+    }
     return allClients.find((el) => el.internalId == windowId);
 }
 
 function shouldShowWindow(client) {
     if (filteredClients.includes(client)) return false;
     if (client.active || client.specialWindow) return false;
+    if (client.skipTaskbar || client.skipSwitcher || client.skipPager) return false;
     if (!showMinimizedWindows && client.minimized) return false;
     if (!showOtherScreensWindows && client.output !== KWinComponents.Workspace.activeScreen) return false;
     if (!showOtherDesktopsWindows && !client.desktops.length || !client.desktops.includes(KWinComponents.Workspace.currentDesktop)) return false;

--- a/contents/ui/components/CornerButton.qml
+++ b/contents/ui/components/CornerButton.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls 2.12
 import org.kde.plasma.components 3.0 as PlasmaComponents
 
 PlasmaComponents.Button {
-        x: mainWindow.width - 50
+        x: mainWindow.width - 72
         height: 30
         width: 30
         visible: true

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -216,6 +216,22 @@ Window {
             /// Cap to chooser area so the grid never spills out of a narrow tile.
             width: Math.min(columnsCount * (cardWidth + gridSpacing), mainWindow.width - gridSpacing)
 
+            /// Faster mouse-wheel scrolling. ScrollView's default is ~20px/notch,
+            /// which is sluggish in long card lists. Bump to roughly one card per
+            /// notch (cardHeight + gridSpacing).
+            WheelHandler {
+                acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
+                onWheel: (event) => {
+                    const fl = scrollView.contentItem;
+                    if (!fl || fl.contentHeight <= fl.height) return;
+                    const step = (cardHeight + gridSpacing) || 120;
+                    const dy = -event.angleDelta.y / 120 * step;
+                    const maxY = fl.contentHeight - fl.height;
+                    fl.contentY = Math.max(0, Math.min(maxY, fl.contentY + dy));
+                    event.accepted = true;
+                }
+            }
+
             Grid {
                 id: gridView
                 /// Dynamic columns: cap at how many cards physically fit at the current

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -24,7 +24,8 @@ Window {
     id: main
     flags: Qt.FramelessWindowHint | Qt.X11BypassWindowManagerHint
     visible: true
-    color: "#50ff0000"
+    /// The backdrop Rectangle inside mainWindow provides the visible fill.
+    color: "transparent"
     x: 0
     y: 0
     height: 1080//currentScreenHeight

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -22,9 +22,15 @@ import "./code/windows.js" as WindowManager
 
 Window {
     id: main
-    flags: Qt.FramelessWindowHint | Qt.X11BypassWindowManagerHint
+    /// X11BypassWindowManagerHint kept Qt focus out of this window on Wayland,
+    /// breaking the keyboardHandler. Use Qt.Tool instead — frameless, on top,
+    /// no taskbar entry, but still in KWin's focus chain so Keys.onPressed
+    /// (Esc/arrows/Enter/Tab) reaches the script.
+    flags: Qt.FramelessWindowHint | Qt.Tool | Qt.WindowStaysOnTopHint
     visible: true
-    /// The backdrop Rectangle inside mainWindow provides the visible fill.
+    /// Transparent — the backdrop Rectangle inside provides the chooser's
+    /// visible fill. The original "#50ff0000" was a development debug color
+    /// that only stayed invisible while immersive mode covered everything.
     color: "transparent"
     x: 0
     y: 0
@@ -455,10 +461,13 @@ Window {
         colorGroup: SystemPalette.Active
     }
 
-    /// Window-level Esc handler — works even if keyboardHandler hasn't grabbed
-    /// active focus (e.g. after clicking the close/layout buttons).
+    /// Esc closes the assist regardless of which sub-element has focus.
+    /// ApplicationShortcut context is needed because `main` uses
+    /// X11BypassWindowManagerHint — it never receives a Qt window-focus event,
+    /// so the default WindowShortcut context would never fire.
     Shortcut {
         sequences: ["Esc"]
+        context: Qt.ApplicationShortcut
         enabled: activated
         onActivated: AssistManager.hideAssist(true)
     }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -343,7 +343,7 @@ Window {
         /// Close assist button
         CornerButton {
             id: closeButton
-            y: 20
+            y: 36
             icon.name: "window-close"
             ToolTip.text: qsTr("Close snap assist (Esc)")
             onClicked: AssistManager.hideAssist(true);
@@ -352,7 +352,7 @@ Window {
         /// Change layout button
         CornerButton {
             id: changeSizeButton
-            y: 60
+            y: 76
 
             Image {
                 anchors.centerIn: parent
@@ -452,6 +452,14 @@ Window {
     SystemPalette {
         id: activePalette
         colorGroup: SystemPalette.Active
+    }
+
+    /// Window-level Esc handler — works even if keyboardHandler hasn't grabbed
+    /// active focus (e.g. after clicking the close/layout buttons).
+    Shortcut {
+        sequences: ["Esc"]
+        enabled: activated
+        onActivated: AssistManager.hideAssist(true)
     }
 
     /// Keyboard handler

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -232,16 +232,29 @@ Window {
                 }
             }
 
-            Grid {
-                id: gridView
-                /// Dynamic columns: cap at how many cards physically fit at the current
-                /// cardWidth. Min 1 so we always have a column even in tiny tiles.
-                columns: Math.max(1, Math.min(columnsCount,
-                    Math.floor((scrollView.width + gridSpacing) / (cardWidth + gridSpacing))))
-                spacing: gridSpacing
-                anchors.horizontalCenter: parent.horizontalCenter
+            /// Wrapper item that fills the ScrollView's viewport. Without this the
+            /// Grid is the contentItem and sizes to its own children, so
+            /// anchors.horizontalCenter has nothing wider to center against and
+            /// cards end up flush-left when there are fewer items than columns.
+            Item {
+                id: gridContainer
+                width: scrollView.width
+                height: gridView.height
+                implicitHeight: gridView.implicitHeight
 
-                Repeater {
+                Grid {
+                    id: gridView
+                    /// Cap columns by (a) the requested layout count, (b) what
+                    /// physically fits at cardWidth, (c) the actual candidate count
+                    /// so a single card doesn't get pushed into a multi-column slot.
+                    columns: Math.max(1, Math.min(
+                        clients ? clients.length : 1,
+                        Math.min(columnsCount,
+                            Math.floor((scrollView.width + gridSpacing) / (cardWidth + gridSpacing)))))
+                    spacing: gridSpacing
+                    anchors.horizontalCenter: parent.horizontalCenter
+
+                    Repeater {
                     id: clientsRepeater
                     model: clients
 
@@ -323,6 +336,7 @@ Window {
                             Behavior on opacity { PropertyAnimation {duration: transitionDuration } }
                         }
                     }
+                }
             }
         }
 

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -71,6 +71,7 @@ Window {
     property int layoutMode: 0 /// 0 - horizontal halve, 1 - quater, 2 - vertical halve
     property var storedQuaterPosition: ({}) /// store initial quater position for Tab button switching
     property var storedFirstQuaterToShow: ({}) /// store planned first quater for Tab button switching
+    property var currentTargetTile: null /// Plasma 6 Tile to assign the next selected window to (set by checkToShowNextQuaterAssist)
 
     /// configurable
     property int transitionDuration
@@ -127,6 +128,8 @@ Window {
 
     Component.onCompleted: {
         loadConfigs();
+        /// DeclarativeScriptWorkspaceWrapper exposes `windows` as a QQmlListProperty;
+        /// `windowList()` only exists on the legacy QtScript wrapper and throws here.
         const windows = KWinComponents.Workspace.windows;
         for (let i = 0; i < windows.length; ++i) {
             WindowManager.addListenersToClient(windows[i]);
@@ -210,13 +213,17 @@ Window {
             id: scrollView
             anchors.centerIn: parent
             height: gridView.height > mainWindow.height * 0.95 ? mainWindow.height * 0.95 : gridView.height
-            width: columnsCount * (cardWidth + gridSpacing)
+            /// Cap to chooser area so the grid never spills out of a narrow tile.
+            width: Math.min(columnsCount * (cardWidth + gridSpacing), mainWindow.width - gridSpacing)
 
             Grid {
                 id: gridView
-                columns: columnsCount
+                /// Dynamic columns: cap at how many cards physically fit at the current
+                /// cardWidth. Min 1 so we always have a column even in tiny tiles.
+                columns: Math.max(1, Math.min(columnsCount,
+                    Math.floor((scrollView.width + gridSpacing) / (cardWidth + gridSpacing))))
                 spacing: gridSpacing
-                anchors.centerIn: parent
+                anchors.horizontalCenter: parent.horizontalCenter
 
                 Repeater {
                     id: clientsRepeater


### PR DESCRIPTION
Brings the `plasma6` WIP branch to a functional state on Plasma 6.6.x.
Tested on Plasma 6.6.5 with a 1.35× fractional output scale.

## What's in here

**Declarative-script API fix.** Three call sites used the QtScript-only
`Workspace.windowList()` which throws at runtime on the declarative-script
workspace wrapper. Switched to the `windows` QQmlListProperty with explicit
index iteration. Existing windows now get listeners attached at script load
(previously only windows opened *after* load worked).

**Tile-aware snap detection.** Plasma 6 introduces a tile tree that the
geometry-only detection in the original script can't see. Added
`onTileChanged()` triggered on `interactiveMoveResizeFinished`
(`tileChanged` alone is unreliable — the `tile` Q_PROPERTY reads
`requestedTile`, which doesn't notify `tileChanged`). Picks one of two
strategies based on the parent tile's structure:

- **Non-overlapping siblings (typical custom layouts):** iterate
  `parent.tiles` directly. Each empty sibling becomes its own chooser
  entry with its `Tile` reference, so placement routes through KWin's
  tile system and the configured tile padding is applied to the
  chosen window (matching what a direct drop produces).
- **Overlapping siblings (Plasma's quick-tile pseudo-tree):**
  fall back to a geometric complement — work area minus the snapped
  window's frame.

The legacy geometry path bails early when `window.tile` is set so the
two paths don't double-fire.

**Window placement.** When the chooser places a candidate into a matched
tile, set `client.tile = currentTargetTile`. KWin's setter handles
positioning with the proper inset; pre-setting `frameGeometry` was
locking the window flush against the bounds and skipping padding.

**Chooser candidate filter.** `shouldShowWindow` now excludes
`skipTaskbar` / `skipSwitcher` / `skipPager` so the XWayland bridge
stops appearing in the chooser.

**Fractional scaling rounding.** `Math.ceil` work-area origin and
`Math.floor` screen dimensions — fractional scales (1.35×, 1.5×…) were
otherwise truncating the y-origin and placing windows one pixel under
the panel.

## Chooser UI polish

- Cards horizontally centered inside the chooser (wrap the Grid in a
  sized Item so `anchors.horizontalCenter` has a viewport to center
  against; cap Grid columns to actual candidate count).
- Grid columns computed dynamically from the available chooser width so
  cards wrap instead of spilling out of narrow tiles (e.g. a 25% strip).
- `cardWidth` bounded by chooser width so even a single card fits.
- Faster mouse-wheel scrolling (one card per notch via `WheelHandler`).
- Close & layout corner buttons moved a bit further inset.
- `Esc` bound at the Window level via a `Shortcut`, so it closes the
  assist regardless of which sub-element has keyboard focus.
- `main.color` switched from the development `#50ff0000` to
  `transparent` — the visible fill comes from the backdrop Rectangle
  inside `mainWindow`. The red only stayed hidden while immersive mode
  covered the screen with the backdrop on top.

## Caveats

- All changes target Plasma 6.6.x. Plasma 5 isn't tested here.
- Plasma 6.6's tile tree quirks (the `tile` Q_PROPERTY reading
  `requestedTile` while `tileChanged` only fires on the *committed*
  tile) are worked around but not "fixed" — upstream KWin would need
  to either notify on requestedTile changes or split the property.